### PR TITLE
Add Arctis Nova 7 support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,27 +303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_more"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
-]
-
-[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,6 +448,12 @@ name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -620,9 +605,9 @@ dependencies = [
  "core-foundation",
  "coreaudio-sys",
  "ctrlc",
- "derive_more",
  "hidapi",
  "notify-rust",
+ "strum",
  "thiserror",
  "tracing",
  "tracing-journald",
@@ -936,6 +921,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,12 +1143,6 @@ name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "valuable"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2024"
 
 [dependencies]
 ctrlc = { version = "3.5.0", features = ["termination"] }
-derive_more = { version = "2.0.1", features = ["display"] }
 hidapi = "2.6.3"
 notify-rust = "4.11.7"
+strum = {version = "0.27.2", features = ["derive"]}
 thiserror = "2.0.16"
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -1,10 +1,12 @@
-use derive_more::Display;
 use hidapi::HidApi;
+use nova_7::Nova7;
 use nova_pro_wireless::NovaProWireless;
 use std::sync::{Arc, atomic::AtomicBool};
+use strum::EnumIter;
 
 use crate::error::DeviceError;
 
+mod nova_7;
 mod nova_pro_wireless;
 
 pub trait Device {
@@ -18,20 +20,22 @@ pub trait Device {
     fn poll_volumes(&self) -> Result<Option<(u8, u8)>, DeviceError>;
 
     fn output_name(&self) -> &'static str;
+    fn output_name_pretty(&self) -> String;
 
     fn close_handle(&self) -> Arc<AtomicBool>;
 }
 
-#[derive(Debug, Display)]
+#[derive(Debug, EnumIter)]
 pub enum DeviceKind {
-    #[display("Nova Pro Wireless")]
     NovaProWireless,
+    Nova7,
 }
 
 impl DeviceKind {
     pub fn probe(&self, api: &HidApi) -> Result<Box<dyn Device>, DeviceError> {
         match self {
             DeviceKind::NovaProWireless => Ok(Box::new(NovaProWireless::new(api)?)),
+            DeviceKind::Nova7 => Ok(Box::new(Nova7::new(api)?)),
         }
     }
 }

--- a/src/device/mod.rs
+++ b/src/device/mod.rs
@@ -20,7 +20,7 @@ pub trait Device {
     fn poll_volumes(&self) -> Result<Option<(u8, u8)>, DeviceError>;
 
     fn output_name(&self) -> &'static str;
-    fn output_name_pretty(&self) -> String;
+    fn display_name(&self) -> String;
 
     fn close_handle(&self) -> Arc<AtomicBool>;
 }

--- a/src/device/nova_7.rs
+++ b/src/device/nova_7.rs
@@ -78,7 +78,7 @@ impl Device for Nova7 {
         "SteelSeries_Arctis_Nova_7"
     }
 
-    fn output_name_pretty(&self) -> String {
+    fn display_name(&self) -> String {
         self.output_name()
             .replace("SteelSeries_", "")
             .replace("_", " ")

--- a/src/device/nova_7.rs
+++ b/src/device/nova_7.rs
@@ -3,50 +3,36 @@ use hidapi::{HidApi, HidDevice};
 use std::sync::{Arc, atomic::AtomicBool};
 use tracing::debug;
 
-pub struct NovaProWireless {
+pub struct Nova7 {
     dev: HidDevice,
     close: Arc<AtomicBool>,
 }
 
-impl NovaProWireless {
+impl Nova7 {
     const VID: u16 = 0x1038;
-    const PID: u16 = 0x12E0;
-    const INTERFACE: i32 = 0x4;
+    const PIDS: [u16; 6] = [
+        0x2202, // Arctis Nova 7
+        0x2206, // Arctis Nova 7X
+        0x2258, // Arctis Nova 7X v2
+        0x220a, // Arctis Nova 7P
+        0x223a, // Arctis Nova 7 Diablo IV
+        0x227a, // Arctis Nova 7 WOW Edition
+    ];
+    const INTERFACE: i32 = 0x5;
 
-    const MSGLEN: usize = 63;
+    const MSGLEN: usize = 8;
     const READ_TIMEOUT: i32 = 1000;
 
     const OPT_CHATMIX: u8 = 0x45;
-
-    const TX: u8 = 0x6;
-    const OPT_CHATMIX_ENABLE: u8 = 0x49;
-    const OPT_SONAR_ICON: u8 = 0x8D;
-
-    fn write_msg(&self, bytes: &[u8]) -> Result<(), DeviceError> {
-        let mut data = [0u8; Self::MSGLEN];
-        let len = bytes.len().min(Self::MSGLEN);
-        data[..len].copy_from_slice(bytes);
-
-        self.dev.write(&data)?;
-        Ok(())
-    }
-
-    fn set_chatmix(&self, state: bool) -> Result<(), DeviceError> {
-        self.write_msg(&[Self::TX, Self::OPT_CHATMIX_ENABLE, state as u8])
-    }
-
-    fn set_sonar_icon(&self, state: bool) -> Result<(), DeviceError> {
-        self.write_msg(&[Self::TX, Self::OPT_SONAR_ICON, state as u8])
-    }
 }
 
-impl Device for NovaProWireless {
+impl Device for Nova7 {
     fn new(api: &HidApi) -> Result<Self, DeviceError> {
         let dev = api
             .device_list()
             .find(|d| {
                 d.vendor_id() == Self::VID
-                    && d.product_id() == Self::PID
+                    && Self::PIDS.contains(&d.product_id())
                     && d.interface_number() == Self::INTERFACE
             })
             .ok_or(DeviceError::NotFound)?
@@ -59,26 +45,22 @@ impl Device for NovaProWireless {
     }
 
     fn enable(&self) -> Result<(), DeviceError> {
-        self.set_sonar_icon(true)?;
-        self.set_chatmix(true)?;
         Ok(())
     }
 
     fn disable(&self) -> Result<(), DeviceError> {
-        self.set_sonar_icon(false)?;
-        self.set_chatmix(false)?;
         Ok(())
     }
 
     fn poll_volumes(&self) -> Result<Option<(u8, u8)>, DeviceError> {
         let mut buf = [0u8; Self::MSGLEN];
         let n = self.dev.read_timeout(&mut buf, Self::READ_TIMEOUT)?;
-        if n == 0 || buf[1] != Self::OPT_CHATMIX {
+        if n == 0 || buf[0] != Self::OPT_CHATMIX {
             return Ok(None);
         }
 
-        let gamevol = buf[2];
-        let chatvol = buf[3];
+        let gamevol = buf[1];
+        let chatvol = buf[2];
 
         debug!("Received volumes: game={}, chat={}", gamevol, chatvol);
 
@@ -86,7 +68,14 @@ impl Device for NovaProWireless {
     }
 
     fn output_name(&self) -> &'static str {
-        "SteelSeries_Arctis_Nova_Pro_Wireless"
+        if let Ok(device_info) = self.dev.get_device_info() {
+            match device_info.product_id() {
+                0x2206 | 0x2258 => return "SteelSeries_Arctis_Nova_7X",
+                0x220a => return "SteelSeries_Arctis_Nova_7P",
+                _ => (),
+            }
+        }
+        "SteelSeries_Arctis_Nova_7"
     }
 
     fn output_name_pretty(&self) -> String {
@@ -100,7 +89,7 @@ impl Device for NovaProWireless {
     }
 }
 
-impl Drop for NovaProWireless {
+impl Drop for Nova7 {
     fn drop(&mut self) {
         let _ = self.disable();
     }

--- a/src/device/nova_pro_wireless.rs
+++ b/src/device/nova_pro_wireless.rs
@@ -89,7 +89,7 @@ impl Device for NovaProWireless {
         "SteelSeries_Arctis_Nova_Pro_Wireless"
     }
 
-    fn output_name_pretty(&self) -> String {
+    fn display_name(&self) -> String {
         self.output_name()
             .replace("SteelSeries_", "")
             .replace("_", " ")

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn main() -> Result<(), Error> {
     loop {
         match try_probe(&api) {
             Some((dev, _)) => {
-                info!("{} found", dev.output_name_pretty());
+                info!("{} found", dev.display_name());
 
                 let close = dev.close_handle();
 
@@ -51,8 +51,8 @@ fn main() -> Result<(), Error> {
                     }
                 }
 
-                info!("{} disconnected", dev.output_name_pretty());
-                notify(&format!("{} disconnected", dev.output_name_pretty()));
+                info!("{} disconnected", dev.display_name());
+                notify(&format!("{} disconnected", dev.display_name()));
 
                 close.store(true, Ordering::SeqCst);
             }
@@ -83,7 +83,7 @@ fn run_device(dev: &dyn Device) -> Result<(), Error> {
     let chatmix = ChatMix::new(dev.output_name())?;
     dev.enable()?;
 
-    notify(&format!("{} connected", dev.output_name_pretty()));
+    notify(&format!("{} connected", dev.display_name()));
 
     let close = dev.close_handle();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use crate::{
 use hidapi::HidApi;
 use notify_rust::Notification;
 use std::{sync::atomic::Ordering, thread, time::Duration};
+use strum::IntoEnumIterator;
 use tracing::{debug, error, info, trace, warn};
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
@@ -37,12 +38,12 @@ fn main() -> Result<(), Error> {
 
     loop {
         match try_probe(&api) {
-            Some((dev, kind)) => {
-                info!("{kind:?} found");
+            Some((dev, _)) => {
+                info!("{} found", dev.output_name_pretty());
 
                 let close = dev.close_handle();
 
-                if let Err(e) = run_device(&*dev, &kind) {
+                if let Err(e) = run_device(&*dev) {
                     error!("run_device failed: {e:?}");
 
                     if let Error::ChatMix(_) = e {
@@ -50,8 +51,8 @@ fn main() -> Result<(), Error> {
                     }
                 }
 
-                info!("{kind:?} disconnected");
-                notify(&format!("{kind:?} disconnected"));
+                info!("{} disconnected", dev.output_name_pretty());
+                notify(&format!("{} disconnected", dev.output_name_pretty()));
 
                 close.store(true, Ordering::SeqCst);
             }
@@ -66,9 +67,7 @@ fn main() -> Result<(), Error> {
 }
 
 fn try_probe(api: &HidApi) -> Option<(Box<dyn Device>, DeviceKind)> {
-    let supported = [DeviceKind::NovaProWireless];
-
-    for kind in supported {
+    for kind in DeviceKind::iter() {
         trace!("Probing device: {kind:?}");
 
         match kind.probe(api) {
@@ -80,11 +79,11 @@ fn try_probe(api: &HidApi) -> Option<(Box<dyn Device>, DeviceKind)> {
     None
 }
 
-fn run_device(dev: &dyn Device, kind: &DeviceKind) -> Result<(), Error> {
+fn run_device(dev: &dyn Device) -> Result<(), Error> {
     let chatmix = ChatMix::new(dev.output_name())?;
     dev.enable()?;
 
-    notify(&format!("{kind} connected"));
+    notify(&format!("{} connected", dev.output_name_pretty()));
 
     let close = dev.close_handle();
 


### PR DESCRIPTION
This pull request adds Arctis Nova 7 support (along with some derivatives). I specifically own the Arctis Nova 7X and have tested with that.

As a bonus, I have also made the headset names show up nicer in the logs and the notification, and I removed the hardcoded `let supported = [DeviceKind::NovaProWireless];` part, instead just iterating over the enum itself.

Thank you for having such good rust code! It was very easy to follow how the program works, and since it was so modular it was easy to add additional headset support!